### PR TITLE
refact(demo2): modded to be imported as a subapp

### DIFF
--- a/apps/core/src/app.tsx
+++ b/apps/core/src/app.tsx
@@ -5,11 +5,6 @@ export const home = declareSubApp({
   getModule: () => import("./home"),
 });
 
-export const Demo2 = declareSubApp({
-  name: "demo2",
-  getModule: () => import("./demo2"),
-});
-
 export const Demo3 = declareSubApp({
   name: "demo3",
   getModule: () => import("./demo3"),

--- a/apps/core/src/demo2/index.tsx
+++ b/apps/core/src/demo2/index.tsx
@@ -6,34 +6,34 @@
 // provides the redux top level store facility.
 //
 
-import { React, ReactSubApp } from "@xarc/react";
-import { reduxFeature, connect } from "@xarc/react-redux";
-export { reduxReducers } from "./reducers";
+import { React, ReactSubApp, declareSubApp } from '@xarc/react';
+import { reduxFeature, connect } from '@xarc/react-redux';
+export { reduxReducers } from './reducers';
 
 const incNumber = () => {
   return {
-    type: "INC_NUMBER",
+    type: 'INC_NUMBER',
   };
 };
 
 const decNumber = () => {
   return {
-    type: "DEC_NUMBER",
+    type: 'DEC_NUMBER',
   };
 };
 
-const Demo2 = (props) => {
+const Demo2 = (props: { value: any; dispatch: any; }) => {
   const { value, dispatch } = props;
 
   return (
     <div>
       <div
         style={{
-          padding: "5px",
-          marginTop: "15px",
-          border: "solid",
-          marginLeft: "15%",
-          marginRight: "15%",
+          padding: '5px',
+          marginTop: '15px',
+          border: 'solid',
+          marginLeft: '15%',
+          marginRight: '15%',
         }}
       >
         <h2>subapp demo2 with Redux</h2>
@@ -45,7 +45,7 @@ const Demo2 = (props) => {
   );
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state: { number: { value: any; }; }) => {
   return { value: state.number.value };
 };
 
@@ -62,3 +62,8 @@ export const subapp: ReactSubApp = {
     }),
   ],
 };
+
+export const subApp = declareSubApp({
+  name: 'demo2',
+  getModule: () => import('./'),
+});

--- a/apps/core/src/home/index.tsx
+++ b/apps/core/src/home/index.tsx
@@ -1,11 +1,30 @@
 import { React, ReactSubApp, createDynamicComponent, staticPropsFeature } from '@xarc/react';
 import electrodePng from '../../static/electrode.png';
 import { message } from './message';
+import { reduxReducers as homeReducers } from './reducers';
 import { subApp as demo1SubApp } from '../demo1';
+import { subApp as demo2SubApp, reduxReducers as demo2Reducers } from '../demo2';
+import { connect, reduxFeature } from '@xarc/react-redux';
 
 export const Demo1 = createDynamicComponent(demo1SubApp, { ssr: false });
+export const Demo2 = createDynamicComponent(demo2SubApp, { ssr: false });
 
-const Home = (props: any) => {
+const updateMessage = (value: string) => {
+  return {
+    type: 'UPDATE_MESSAGE',
+    payload: value,
+  };
+};
+
+const removeMessage = () => {
+  return {
+    type: 'REMOVE_MESSAGE',
+  };
+};
+
+console.log(']>--------------<[Home]')
+const Home = (props: { value: string; dispatch: any }) => {
+  const { value, dispatch } = props;
   return (
     <div style={{ textAlign: 'center' }}>
       <h1>
@@ -13,19 +32,35 @@ const Home = (props: any) => {
           Electrode <img src={electrodePng} />
         </a>
       </h1>
-      <p>{message}</p>
+      <p>{value}</p>
       <p>props: {JSON.stringify(props)}</p>
+      <h1>Redux State Home</h1>
+      <button onClick={() => dispatch(updateMessage(message))}>Show message</button>
+      &nbsp;{value}&nbsp;
+      <button onClick={() => dispatch(removeMessage())}>Delete message</button>
       <h1>Demo1 subapp as a dynamic component in Home</h1>
       <Demo1 />
+      <Demo2 />
     </div>
   );
 };
+const mapStateToProps = (state: { message: { value: string } }) => {
+  return { value: state.message.value };
+};
 
+export const reduxReducers = { ...homeReducers, ...demo2Reducers };
 export const subapp: ReactSubApp = {
-  Component: Home,
+  Component: connect(mapStateToProps, (dispatch) => ({ dispatch }))(Home),
   wantFeatures: [
-    staticPropsFeature({
-      serverModule: require.resolve('./static-props'),
+    reduxFeature({
+      React,
+      shareStore: true,
+      reducers: true, // true => read the reduxReducers export from this file
+      prepare: async (initialState) => {
+        return {
+          initialState: initialState || { message: { value: 'none' }, number: { value: 999 } },
+        };
+      },
     }),
   ],
 };

--- a/apps/core/src/home/reducers.ts
+++ b/apps/core/src/home/reducers.ts
@@ -1,0 +1,17 @@
+const message = (store = { value: 'none' }, action: { type: string; payload: any }) => {
+  if (action.type === 'UPDATE_MESSAGE') {
+    return {
+      value: action.payload,
+    };
+  } else if (action.type === 'REMOVE_MESSAGE') {
+    return {
+      value: 'none',
+    };
+  }
+
+  return store;
+};
+
+export const reduxReducers = {
+  message,
+};

--- a/apps/core/src/server/routes.ts
+++ b/apps/core/src/server/routes.ts
@@ -1,4 +1,4 @@
-import { Demo2, Demo3, home } from "../app";
+import { Demo3, home } from "../app";
 import { PageRenderer } from "@xarc/react";
 import { ElectrodeFastifyInstance } from "@xarc/fastify-server";
 /**
@@ -12,7 +12,6 @@ export async function fastifyPlugin(server: ElectrodeFastifyInstance) {
     pageTitle: "xarc React App demo",
     subApps: [
       { name: home.name, ssr: true },
-      { name: Demo2.name, ssr: true },
       { name: Demo3.name, ssr: true },
     ],
     prodAssetData: {


### PR DESCRIPTION
In this PR we are moving the demo2 subapp to be used from the home subapp instead of being rendered from server/routes
